### PR TITLE
Add shorthand ‘ID’ type alias for ‘Identifier<Self>’

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,16 @@ struct User: Identifiable {
 }
 ```
 
-And just like that, the above `User` identifier is now type-safe!
+And just like that, the above `User` identifier is now type-safe! Thanks to Swift’s type inference capabilities, it’s also possible to implement an `Identifiable` type’s `id` simply by using `ID` as its type:
+
+```swift
+struct User: Identifiable {
+    let id: ID
+    let name: String
+}
+```
+
+The `ID` type alias is automatically added for all `Identifiable` types, which also makes it possible to refer to `Identifier<User>` as `User.ID`.
 
 ## Customizing the raw type
 
@@ -25,7 +34,7 @@ And just like that, the above `User` identifier is now type-safe!
 struct Article: Identifiable {
     typealias RawIdentifier = UUID
 
-    let id: Identifier<Article>
+    let id: ID
     let title: String
 }
 ```
@@ -58,7 +67,7 @@ articleManager.article(withID: user.id)
 
 The compiler will give us an error above, since we're trying to pass an `Identifier<User>` value to a method that accepts an `Identifier<Article>` - giving us much stronger type safety than when using plain values, like `String` or `Int`, as identifiers.
 
-Identity also makes it impossible to accidentially declare `id` properties of the wrong type. So the following won't compile either:
+Identity also makes it impossible to accidentally declare `id` properties of the wrong type. So the following won't compile either:
 
 ```swift
 struct User: Identifiable {

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -14,8 +14,10 @@ import Foundation
 public protocol Identifiable {
     /// The backing raw type of this type's identifier.
     associatedtype RawIdentifier = String
+    /// Shorthand type alias for this type's identifier.
+    typealias ID = Identifier<Self>
     /// The ID of this instance.
-    var id: Identifier<Self> { get }
+    var id: ID { get }
 }
 
 /// A type-safe identifier for a given `Value`, backed by a raw value.

--- a/Tests/IdentityTests/IdentityTests.swift
+++ b/Tests/IdentityTests/IdentityTests.swift
@@ -10,7 +10,7 @@ import Identity
 final class IdentityTests: XCTestCase {
     func testStringBasedIdentifier() {
         struct Model: Identifiable {
-            let id: Identifier<Model>
+            let id: ID
         }
 
         let model = Model(id: "Hello, world!")
@@ -20,7 +20,7 @@ final class IdentityTests: XCTestCase {
     func testIntBasedIdentifier() {
         struct Model: Identifiable {
             typealias RawIdentifier = Int
-            let id: Identifier<Model>
+            let id: ID
         }
 
         let model = Model(id: 7)
@@ -30,7 +30,7 @@ final class IdentityTests: XCTestCase {
     func testCodableIdentifier() throws {
         struct Model: Identifiable, Codable {
             typealias RawIdentifier = UUID
-            let id: Identifier<Model>
+            let id: ID
         }
 
         let model = Model(id: Identifier(rawValue: UUID()))
@@ -41,7 +41,7 @@ final class IdentityTests: XCTestCase {
 
     func testIdentifierEncodedAsSingleValue() throws {
         struct Model: Identifiable, Codable {
-            let id: Identifier<Model>
+            let id: ID
         }
 
         let model = Model(id: "I'm an ID")


### PR DESCRIPTION
Makes it more convenient to implement `Identifiable`, since the type of `Identifier` will be automatically inferred by the compiler. Plus using `Type.ID` to refer to an ID is usually nicer than `Identifier<Type>`.