### PR TITLE
Enable IDs to be expressed using string interpolation

### DIFF
--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -65,6 +65,10 @@ extension Identifier: ExpressibleByStringLiteral
     }
 }
 
+extension Identifier: ExpressibleByStringInterpolation
+          where Value.RawIdentifier: ExpressibleByStringInterpolation,
+                Value.RawIdentifier.StringLiteralType == String {}
+
 // MARK: - Compiler-generated protocol support
 
 extension Identifier: Equatable where Value.RawIdentifier: Equatable {}

--- a/Tests/IdentityTests/IdentityTests.swift
+++ b/Tests/IdentityTests/IdentityTests.swift
@@ -50,6 +50,15 @@ final class IdentityTests: XCTestCase {
         XCTAssertEqual(json?["id"] as? String, "I'm an ID")
     }
 
+    func testExpressingIdentifierUsingStringInterpolation() {
+        struct Model: Identifiable {
+            let id: ID
+        }
+
+        let model = Model(id: "Hello, world!")
+        XCTAssertEqual(model.id, "Hello, \("world!")")
+    }
+
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -60,6 +69,7 @@ extension IdentityTests: LinuxTestable {
         ("testStringBasedIdentifier", testStringBasedIdentifier),
         ("testIntBasedIdentifier", testIntBasedIdentifier),
         ("testCodableIdentifier", testCodableIdentifier),
-        ("testIdentifierEncodedAsSingleValue", testIdentifierEncodedAsSingleValue)
+        ("testIdentifierEncodedAsSingleValue", testIdentifierEncodedAsSingleValue),
+        ("testExpressingIdentifierUsingStringInterpolation", testExpressingIdentifierUsingStringInterpolation)
     ]
 }


### PR DESCRIPTION
Add automatic conformance to `ExpressibleByStringInterpolation` whenever an identifier’s raw value conforms to that protocol with `String` as its literal type.