### PR TITLE
Add support for string descriptions

### DIFF
--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -69,6 +69,14 @@ extension Identifier: ExpressibleByStringInterpolation
           where Value.RawIdentifier: ExpressibleByStringInterpolation,
                 Value.RawIdentifier.StringLiteralType == String {}
 
+// MARK: - String conversion support
+
+extension Identifier: CustomStringConvertible {
+    public var description: String {
+        return "\(rawValue)"
+    }
+}
+
 // MARK: - Compiler-generated protocol support
 
 extension Identifier: Equatable where Value.RawIdentifier: Equatable {}

--- a/Tests/IdentityTests/IdentityTests.swift
+++ b/Tests/IdentityTests/IdentityTests.swift
@@ -59,6 +59,23 @@ final class IdentityTests: XCTestCase {
         XCTAssertEqual(model.id, "Hello, \("world!")")
     }
 
+    func testIdentifierDescription() {
+        struct StringModel: Identifiable {
+            let id: ID
+        }
+
+        struct IntModel: Identifiable {
+            typealias RawIdentifier = Int
+            let id: ID
+        }
+
+        let stringID: StringModel.ID = "An ID"
+        let intID: IntModel.ID = 7
+
+        XCTAssertEqual(stringID.description, "An ID")
+        XCTAssertEqual(intID.description, "7")
+    }
+
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -70,6 +87,7 @@ extension IdentityTests: LinuxTestable {
         ("testIntBasedIdentifier", testIntBasedIdentifier),
         ("testCodableIdentifier", testCodableIdentifier),
         ("testIdentifierEncodedAsSingleValue", testIdentifierEncodedAsSingleValue),
-        ("testExpressingIdentifierUsingStringInterpolation", testExpressingIdentifierUsingStringInterpolation)
+        ("testExpressingIdentifierUsingStringInterpolation", testExpressingIdentifierUsingStringInterpolation),
+        ("testIdentifierDescription", testIdentifierDescription)
     ]
 }


### PR DESCRIPTION
This enables an identifier to be described as a string, by proxying its raw identifier’s description.