### PR TITLE
Add manual implementation of the Hashable protocol

### DIFF
--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -77,10 +77,18 @@ extension Identifier: CustomStringConvertible {
     }
 }
 
+// MARK: - Hashable support
+
+extension Identifier: Hashable where Value.RawIdentifier: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(Value.self))
+        hasher.combine(rawValue)
+    }
+}
+
 // MARK: - Compiler-generated protocol support
 
 extension Identifier: Equatable where Value.RawIdentifier: Equatable {}
-extension Identifier: Hashable where Value.RawIdentifier: Hashable {}
 
 // MARK: - Codable support
 

--- a/Tests/IdentityTests/IdentityTests.swift
+++ b/Tests/IdentityTests/IdentityTests.swift
@@ -76,6 +76,21 @@ final class IdentityTests: XCTestCase {
         XCTAssertEqual(intID.description, "7")
     }
 
+    func testIdentifierHashValue() {
+        struct FirstModel: Identifiable {
+            let id: ID
+        }
+
+        struct SecondModel: Identifiable {
+            let id: ID
+        }
+
+        let first = FirstModel(id: "0")
+        let second = SecondModel(id: "0")
+
+        XCTAssertNotEqual(first.id.hashValue, second.id.hashValue)
+    }
+
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -88,6 +103,7 @@ extension IdentityTests: LinuxTestable {
         ("testCodableIdentifier", testCodableIdentifier),
         ("testIdentifierEncodedAsSingleValue", testIdentifierEncodedAsSingleValue),
         ("testExpressingIdentifierUsingStringInterpolation", testExpressingIdentifierUsingStringInterpolation),
-        ("testIdentifierDescription", testIdentifierDescription)
+        ("testIdentifierDescription", testIdentifierDescription),
+        ("testIdentifierHashValue", testIdentifierHashValue),
     ]
 }


### PR DESCRIPTION
Models with different types can have `id`s with the same `rawValue`. In the current implementation, such `id`s have the same `hashValue`.

It can cause problems and inefficiencies wherever the `hashValue` is used (`Dictionary`, `Set` and others).

For example:
```swift
protocol Model {}

struct User: Identifiable, Model {
    let id: ID
}

struct Offer: Identifiable, Model {
    let id: ID
}

let user = User(id: "0")
let offer = Offer(id: "0")

var dictionary = [AnyHashable: Model]()
dictionary[user.id] = user
dictionary[offer.id] = offer

print(user.id.hashValue) // -8325541509441078555
print(offer.id.hashValue) // -8325541509441078555
print(AnyHashable(user.id).hashValue) // -8325541509441078555
print(AnyHashable(offer.id).hashValue) // -8325541509441078555
```

This example causes collision in the dictionary. The collision will be successfully resolved because [Equatable implementation in AnyHashable checks that compared items have the same type](https://github.com/apple/swift/blob/master/stdlib/public/core/AnyHashable.swift#L77).
```swift
print(AnyHashable(user.id) == AnyHashable(offer.id)) // false
```
But it is bad for computable [complexity](https://opensource.apple.com/source/CF/CF-855.11/CFDictionary.h).

> Computational Complexity
> The access time for a value in the dictionary is guaranteed to be at worst O(N) for any implementation, current and future, but will often be O(1) (constant time). Insertion or deletion operations will typically be constant time as well, but are O(N*N) in the worst case in some implementations. Access of values through a key is faster than accessing values directly (if there are any such operations). Dictionaries will tend to use significantly more memory than a array with the same number of values.

I propose considering the type of `Identifier.Value` when calculating the hash.