### PR TITLE
Makes Identifier RawRepresentable (explicitely)

### DIFF
--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -23,7 +23,7 @@ public protocol Identifiable {
 /// A type-safe identifier for a given `Value`, backed by a raw value.
 /// When backed by a `Codable` type, `Identifier` also becomes codable,
 /// and will be encoded into a single value according to its raw value.
-public struct Identifier<Value: Identifiable> {
+public struct Identifier<Value: Identifiable>: RawRepresentable {
     /// The raw value that is backing this identifier.
     public let rawValue: Value.RawIdentifier
 


### PR DESCRIPTION
From what I can see, `Identifier` is already complying to the `RawRepresentable` protocol implicitly:
It has `public let rawValue` + `public init(rawValue: Value.RawIdentifier)`.

This just adds this compliance **explicitly**.

For my use case this fixes the JSON parsing (using [Arrow](https://github.com/freshOS/Arrow))
```swift

extension YPBreed: ArrowParsable {
    public mutating func deserialize(_ json: JSON) {
        let resource = resourceKeyFrom(json)
        id <-- resource["id"]
        [...]
    }
}
```
Prior, the parsing wouldn't work since it relies on RawRepresentable 👍 
